### PR TITLE
Add test results summary to Node/React test evidence

### DIFF
--- a/.cloudbees/workflows/test-generic.yaml
+++ b/.cloudbees/workflows/test-generic.yaml
@@ -121,7 +121,7 @@ jobs:
           REACT_APP_SHOW_DEBUG_FOOTER: "1"
         run: |
           set -eu
-          apk add --no-cache git
+          apk add --no-cache git libxml2-utils
           echo "Node: $(node -v)"; echo "NPM: $(npm -v)"
           npm ci
           npm i -D jest-junit
@@ -147,6 +147,25 @@ jobs:
           set +o pipefail
           set -e
 
+          # Parse test results from JUnit XML
+          if [ -f junit.xml ]; then
+            TOTAL=$(xmllint --xpath "count(//testcase)" junit.xml 2>/dev/null || echo "0")
+            FAILED=$(xmllint --xpath "count(//testcase/failure)" junit.xml 2>/dev/null || echo "0")
+            ERRORS=$(xmllint --xpath "count(//testcase/error)" junit.xml 2>/dev/null || echo "0")
+            SKIPPED=$(xmllint --xpath "count(//testcase/skipped)" junit.xml 2>/dev/null || echo "0")
+            PASSED=$((TOTAL - FAILED - ERRORS - SKIPPED))
+
+            {
+              echo "**Tests Run:** $TOTAL"
+              echo "**Passed:** $PASSED"
+              echo "**Failed:** $FAILED"
+              echo "**Errors:** $ERRORS"
+              echo "**Skipped:** $SKIPPED"
+            } > "$CLOUDBEES_OUTPUTS/TEST_SUMMARY"
+          else
+            echo "No test results available" > "$CLOUDBEES_OUTPUTS/TEST_SUMMARY"
+          fi
+
           if [ -s coverage_stdout.txt ]; then
             { echo '```'; cat coverage_stdout.txt; echo '```'; } > "$CLOUDBEES_OUTPUTS/CODE_COVERAGE"
           else
@@ -171,7 +190,11 @@ jobs:
           format: MARKDOWN
           content: |
             ## Test Stage (Node)
-            Code coverage (if available):
+
+            ### Test Results
+            ${{ steps.NodeTests.outputs.TEST_SUMMARY }}
+
+            ### Code Coverage
             ${{ steps.NodeTests.outputs.CODE_COVERAGE }}
 
       # --------------------- PYTHON ---------------------
@@ -233,6 +256,7 @@ jobs:
           GO_COV: ${{ steps.GoTests.outputs.CODE_COVERAGE }}
           GO_TEST: ${{ steps.GoTests.outputs.TEST_SUMMARY }}
           NODE_COV: ${{ steps.NodeTests.outputs.CODE_COVERAGE }}
+          NODE_TEST: ${{ steps.NodeTests.outputs.TEST_SUMMARY }}
           PY_COV: ${{ steps.PyTests.outputs.CODE_COVERAGE }}
         run: |
           set -eu
@@ -248,6 +272,8 @@ jobs:
 
           if [ -n "${GO_TEST:-}" ]; then
             printf '%s\n' "$GO_TEST" > "$CLOUDBEES_OUTPUTS/TEST_SUMMARY"
+          elif [ -n "${NODE_TEST:-}" ]; then
+            printf '%s\n' "$NODE_TEST" > "$CLOUDBEES_OUTPUTS/TEST_SUMMARY"
           else
             echo "No test summary available" > "$CLOUDBEES_OUTPUTS/TEST_SUMMARY"
           fi


### PR DESCRIPTION
## Summary

Adds test result statistics to Node/React test evidence, matching the functionality already implemented for Go tests.

## Problem

Node/React tests were generating JUnit XML but not parsing it to show test statistics in evidence. Only code coverage was displayed.

## Solution

- Parse JUnit XML output from Jest to extract test counts
- Add TEST_SUMMARY output with pass/fail/error/skip statistics
- Update Node evidence template to display test results section
- Update ChooseCoverage step to handle NODE_TEST summary
- Install libxml2-utils for XML parsing in Node container

## Changes

**For Node tests:**
- Added libxml2-utils dependency
- Parse JUnit XML after test execution
- Create TEST_SUMMARY output matching Go format
- Enhanced evidence with "Test Results" section

**For Go tests:**
- No changes - remains exactly the same
- Backward compatible

## Evidence Format

Node test evidence now shows:

### Test Results
**Tests Run:** 62
**Passed:** 62
**Failed:** 0
**Errors:** 0
**Skipped:** 0

### Code Coverage
```
(coverage details...)
```

## Testing

- Validated with kraken-auth (Go) - no regression
- Validated with squid-ui (Node/React) - test summary now appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)