### PR TITLE
Add Smart Tests build name output and release-generic workflow

### DIFF
--- a/.cloudbees/workflows/release-generic.yaml
+++ b/.cloudbees/workflows/release-generic.yaml
@@ -1,0 +1,78 @@
+apiVersion: automation.cloudbees.io/v1alpha1
+kind: workflow
+name: Generic Release Trigger
+on:
+  workflow_call:
+    inputs:
+      component_name:
+        type: string
+        required: true
+        description: "Component name (e.g. 'jellyfish-notifications')"
+      component_id:
+        type: string
+        required: true
+        description: "CloudBees Unify component ID (e.g. '0412edae-fc75-4ff4-9bd4-8b5875513aeb')"
+      version:
+        type: string
+        required: true
+        description: "Version to deploy (from build output)"
+      smart_tests_build_name:
+        type: string
+        required: false
+        default: ""
+        description: "Smart Tests build name from test job (for E2E test linking)"
+      environment:
+        type: string
+        required: false
+        default: "squid-demo-3"
+        description: "Target environment for release"
+      release_name_prefix:
+        type: string
+        required: false
+        default: ""
+        description: "Release name prefix (defaults to shortened component name)"
+
+jobs:
+  trigger-release:
+    steps:
+      - name: Create and run CloudBees Unify release
+        id: release
+        uses: guru-actions/create_release@v0.23
+        with:
+          cb_api_token: ${{ secrets.sb_internal_api }}
+          cb_org_id: "8d16bd77-d506-45e6-a0f4-8884ce16d301"
+          cb_application_id: "e3925a1f-9165-4767-9d6e-a96bb4edc80a"
+          cb_workflow_id: "5a6ea7f6-042c-4724-b58c-0744982966b4"
+          cb_environment: ${{ inputs.environment }}
+          release_name_prefix: ${{ inputs.release_name_prefix != '' && inputs.release_name_prefix || format('{0}-', inputs.component_name) }}
+          component_overrides: "${{ inputs.component_id }}=${{ inputs.version }}"
+          close_on_pass: "true"
+          skip_release_on_missing_artifacts: "false"
+          selection_report_format: "markdown"
+          prevent_concurrent_releases: "wait"
+          queue_check_sleep_seconds: "20"
+          wait_sleep_seconds: "20"
+          max_wait_attempts: "90"
+          enable_api_diagnostics: "true"
+          smart_tests_component: ${{ inputs.component_name }}
+          smart_tests_build_name: ${{ inputs.smart_tests_build_name }}
+
+      - name: Show release status
+        uses: docker://alpine:3.18
+        run: |
+          echo "==================== RELEASE STATUS ===================="
+          echo "Component: ${{ inputs.component_name }}"
+          echo "Version: ${{ inputs.version }}"
+          echo "Environment: ${{ inputs.environment }}"
+          echo "Status: ${{ steps.release.outputs.status }}"
+          echo "Release ID: ${{ steps.release.outputs.release_id }}"
+          echo "Release Name: ${{ steps.release.outputs.release_name }}"
+          echo "Run ID: ${{ steps.release.outputs.run_id }}"
+          echo "========================================================"
+
+      - name: Publish release evidence
+        kind: deploy
+        uses: cloudbees-io/publish-evidence-item@v1
+        with:
+          format: MARKDOWN
+          content: ${{ steps.release.outputs.selection_report }}

--- a/.cloudbees/workflows/test-generic.yaml
+++ b/.cloudbees/workflows/test-generic.yaml
@@ -88,7 +88,7 @@ jobs:
           if [ "${{ inputs.enable_smart_tests }}" = "true" ] && [ -n "${LAUNCHABLE_TOKEN:-}" ]; then
             echo "=== Recording build to Smart Tests ==="
             SMART_TESTS_BUILD_NAME="cb-squidstack-${APP_NAME}-${CLOUDBEES_BUILD_ID}"
-            echo "$SMART_TESTS_BUILD_NAME" > /tmp/smart_tests_build_name.txt
+            printf '%s' "$SMART_TESTS_BUILD_NAME" > /tmp/smart_tests_build_name.txt
             launchable record build --name "$SMART_TESTS_BUILD_NAME" || {
               echo "Warning: Build recording failed, continuing without Smart Tests"
               unset LAUNCHABLE_TOKEN
@@ -204,9 +204,9 @@ jobs:
 
           # Output Smart Tests build name if it was set
           if [ -f /tmp/smart_tests_build_name.txt ]; then
-            cat /tmp/smart_tests_build_name.txt > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
+            printf '%s' "$(cat /tmp/smart_tests_build_name.txt)" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
           else
-            echo "" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
+            printf '%s' "" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
           fi
 
           exit $STATUS
@@ -281,7 +281,7 @@ jobs:
           if [ "${{ inputs.enable_smart_tests }}" = "true" ] && [ -n "${LAUNCHABLE_TOKEN:-}" ]; then
             echo "=== Recording build to Smart Tests ==="
             SMART_TESTS_BUILD_NAME="cb-squidstack-${APP_NAME}-${CLOUDBEES_BUILD_ID}"
-            echo "$SMART_TESTS_BUILD_NAME" > /tmp/smart_tests_build_name.txt
+            printf '%s' "$SMART_TESTS_BUILD_NAME" > /tmp/smart_tests_build_name.txt
             launchable record build --name "$SMART_TESTS_BUILD_NAME" || {
               echo "Warning: Build recording failed, continuing without Smart Tests"
               unset LAUNCHABLE_TOKEN
@@ -395,9 +395,9 @@ jobs:
 
           # Output Smart Tests build name if it was set
           if [ -f /tmp/smart_tests_build_name.txt ]; then
-            cat /tmp/smart_tests_build_name.txt > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
+            printf '%s' "$(cat /tmp/smart_tests_build_name.txt)" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
           else
-            echo "" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
+            printf '%s' "" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
           fi
 
           exit $STATUS
@@ -509,9 +509,9 @@ jobs:
           fi
 
           if [ -n "${GO_SMART_TESTS:-}" ]; then
-            printf '%s\n' "$GO_SMART_TESTS" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
+            printf '%s' "$GO_SMART_TESTS" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
           elif [ -n "${NODE_SMART_TESTS:-}" ]; then
-            printf '%s\n' "$NODE_SMART_TESTS" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
+            printf '%s' "$NODE_SMART_TESTS" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
           else
-            echo "" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
+            printf '%s' "" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
           fi

--- a/.cloudbees/workflows/test-generic.yaml
+++ b/.cloudbees/workflows/test-generic.yaml
@@ -43,7 +43,7 @@ jobs:
     outputs:
       CODE_COVERAGE: ${{ steps.ChooseCoverage.outputs.CODE_COVERAGE }}
       TEST_SUMMARY: ${{ steps.ChooseCoverage.outputs.TEST_SUMMARY }}
-      SMART_TESTS_BUILD_NAME: ${{ steps.SmartTestsBuildName.outputs.BUILD_NAME }}
+      SMART_TESTS_BUILD_NAME: ${{ steps.ChooseCoverage.outputs.SMART_TESTS_BUILD_NAME }}
     steps:
       - name: Checkout source
         uses: cloudbees-io/checkout@v2
@@ -200,6 +200,13 @@ jobs:
             { echo '```'; cat coverage_summary.txt; echo '```'; } > "$CLOUDBEES_OUTPUTS/CODE_COVERAGE"
           else
             { echo '```'; echo '(no coverage output captured)'; echo '```'; } > "$CLOUDBEES_OUTPUTS/CODE_COVERAGE"
+          fi
+
+          # Output Smart Tests build name if it was set
+          if [ -f /tmp/smart_tests_build_name.txt ]; then
+            cat /tmp/smart_tests_build_name.txt > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
+          else
+            echo "" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
           fi
 
           exit $STATUS
@@ -386,6 +393,13 @@ jobs:
             { echo '```'; echo '(no coverage output captured)'; echo '```'; } > "$CLOUDBEES_OUTPUTS/CODE_COVERAGE"
           fi
 
+          # Output Smart Tests build name if it was set
+          if [ -f /tmp/smart_tests_build_name.txt ]; then
+            cat /tmp/smart_tests_build_name.txt > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
+          else
+            echo "" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
+          fi
+
           exit $STATUS
 
       - name: Publish Node test results
@@ -469,8 +483,10 @@ jobs:
         env:
           GO_COV: ${{ steps.GoTests.outputs.CODE_COVERAGE }}
           GO_TEST: ${{ steps.GoTests.outputs.TEST_SUMMARY }}
+          GO_SMART_TESTS: ${{ steps.GoTests.outputs.SMART_TESTS_BUILD_NAME }}
           NODE_COV: ${{ steps.NodeTests.outputs.CODE_COVERAGE }}
           NODE_TEST: ${{ steps.NodeTests.outputs.TEST_SUMMARY }}
+          NODE_SMART_TESTS: ${{ steps.NodeTests.outputs.SMART_TESTS_BUILD_NAME }}
           PY_COV: ${{ steps.PyTests.outputs.CODE_COVERAGE }}
         run: |
           set -eu
@@ -492,13 +508,10 @@ jobs:
             echo "No test summary available" > "$CLOUDBEES_OUTPUTS/TEST_SUMMARY"
           fi
 
-      - name: Capture Smart Tests build name
-        id: SmartTestsBuildName
-        uses: docker://alpine:3.20
-        run: |
-          set -eu
-          if [ -f /tmp/smart_tests_build_name.txt ]; then
-            cat /tmp/smart_tests_build_name.txt > "$CLOUDBEES_OUTPUTS/BUILD_NAME"
+          if [ -n "${GO_SMART_TESTS:-}" ]; then
+            printf '%s\n' "$GO_SMART_TESTS" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
+          elif [ -n "${NODE_SMART_TESTS:-}" ]; then
+            printf '%s\n' "$NODE_SMART_TESTS" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
           else
-            echo "" > "$CLOUDBEES_OUTPUTS/BUILD_NAME"
+            echo "" > "$CLOUDBEES_OUTPUTS/SMART_TESTS_BUILD_NAME"
           fi

--- a/.cloudbees/workflows/test-generic.yaml
+++ b/.cloudbees/workflows/test-generic.yaml
@@ -34,6 +34,8 @@ on:
         value: ${{ jobs.test.outputs.CODE_COVERAGE }}
       TEST_SUMMARY:
         value: ${{ jobs.test.outputs.TEST_SUMMARY }}
+      SMART_TESTS_BUILD_NAME:
+        value: ${{ jobs.test.outputs.SMART_TESTS_BUILD_NAME }}
 
 jobs:
   test:
@@ -41,6 +43,7 @@ jobs:
     outputs:
       CODE_COVERAGE: ${{ steps.ChooseCoverage.outputs.CODE_COVERAGE }}
       TEST_SUMMARY: ${{ steps.ChooseCoverage.outputs.TEST_SUMMARY }}
+      SMART_TESTS_BUILD_NAME: ${{ steps.SmartTestsBuildName.outputs.BUILD_NAME }}
     steps:
       - name: Checkout source
         uses: cloudbees-io/checkout@v2
@@ -84,7 +87,9 @@ jobs:
           # Record build to Smart Tests
           if [ "${{ inputs.enable_smart_tests }}" = "true" ] && [ -n "${LAUNCHABLE_TOKEN:-}" ]; then
             echo "=== Recording build to Smart Tests ==="
-            launchable record build --name "cb-squidstack-${APP_NAME}-${CLOUDBEES_BUILD_ID}" || {
+            SMART_TESTS_BUILD_NAME="cb-squidstack-${APP_NAME}-${CLOUDBEES_BUILD_ID}"
+            echo "$SMART_TESTS_BUILD_NAME" > /tmp/smart_tests_build_name.txt
+            launchable record build --name "$SMART_TESTS_BUILD_NAME" || {
               echo "Warning: Build recording failed, continuing without Smart Tests"
               unset LAUNCHABLE_TOKEN
             }
@@ -268,7 +273,9 @@ jobs:
           # Record build to Smart Tests
           if [ "${{ inputs.enable_smart_tests }}" = "true" ] && [ -n "${LAUNCHABLE_TOKEN:-}" ]; then
             echo "=== Recording build to Smart Tests ==="
-            launchable record build --name "cb-squidstack-${APP_NAME}-${CLOUDBEES_BUILD_ID}" || {
+            SMART_TESTS_BUILD_NAME="cb-squidstack-${APP_NAME}-${CLOUDBEES_BUILD_ID}"
+            echo "$SMART_TESTS_BUILD_NAME" > /tmp/smart_tests_build_name.txt
+            launchable record build --name "$SMART_TESTS_BUILD_NAME" || {
               echo "Warning: Build recording failed, continuing without Smart Tests"
               unset LAUNCHABLE_TOKEN
             }
@@ -483,4 +490,15 @@ jobs:
             printf '%s\n' "$NODE_TEST" > "$CLOUDBEES_OUTPUTS/TEST_SUMMARY"
           else
             echo "No test summary available" > "$CLOUDBEES_OUTPUTS/TEST_SUMMARY"
+          fi
+
+      - name: Capture Smart Tests build name
+        id: SmartTestsBuildName
+        uses: docker://alpine:3.20
+        run: |
+          set -eu
+          if [ -f /tmp/smart_tests_build_name.txt ]; then
+            cat /tmp/smart_tests_build_name.txt > "$CLOUDBEES_OUTPUTS/BUILD_NAME"
+          else
+            echo "" > "$CLOUDBEES_OUTPUTS/BUILD_NAME"
           fi


### PR DESCRIPTION
## Summary
- Add SMART_TESTS_BUILD_NAME output to test-generic workflow
- Create new release-generic reusable workflow to centralize release triggering
- Fix newline issues in Smart Tests build name by using printf instead of echo

## Changes
- **test-generic.yaml**: Added SMART_TESTS_BUILD_NAME output, fixed newline handling
- **release-generic.yaml** (NEW): Reusable workflow for triggering CloudBees Unify releases

## Integration
- Works with guru-actions/create_release@v0.23
- Enables E2E tests to link to component test builds via Smart Tests
- Includes component version overrides to ensure correct artifacts are deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)