### PR TITLE
Remove --test-suite from launchable record tests command

### DIFF
--- a/.cloudbees/workflows/test-generic.yaml
+++ b/.cloudbees/workflows/test-generic.yaml
@@ -171,7 +171,7 @@ jobs:
           # Record test results to Smart Tests
           if [ "${{ inputs.enable_smart_tests }}" = "true" ] && [ -n "${LAUNCHABLE_TOKEN:-}" ] && [ -f junit.xml ]; then
             echo "=== Recording test results to Smart Tests ==="
-            launchable record tests --session "$(cat /tmp/launchable-session.txt)" --test-suite "${APP_NAME}-tests" file junit.xml || {
+            launchable record tests --session "$(cat /tmp/launchable-session.txt)" file junit.xml || {
               echo "Warning: Test result recording failed"
             }
           fi
@@ -363,7 +363,7 @@ jobs:
           # Record test results to Smart Tests
           if [ "${{ inputs.enable_smart_tests }}" = "true" ] && [ -n "${LAUNCHABLE_TOKEN:-}" ] && [ -f junit.xml ]; then
             echo "=== Recording test results to Smart Tests ==="
-            launchable record tests --session "$(cat /tmp/launchable-session.txt)" --test-suite "${APP_NAME}-tests" file junit.xml || {
+            launchable record tests --session "$(cat /tmp/launchable-session.txt)" file junit.xml || {
               echo "Warning: Test result recording failed"
             }
           fi


### PR DESCRIPTION
## Summary
Removes `--test-suite` parameter from `launchable record tests` commands to fix Launchable API compatibility issue.

## Problem
Launchable API now rejects `--test-suite` on the `record tests` command with warning:
```
`--test-suite` option was ignored in the record tests command. 
Add `--test-suite` option to the `record session` command instead.
```

This was causing test result recording to fail across all components.

## Changes
- Removed `--test-suite "${APP_NAME}-tests"` from `record tests` on line 174 (Go tests)
- Removed `--test-suite "${APP_NAME}-tests"` from `record tests` on line 366 (Node tests)
- Kept `--test-suite` on `record session` commands (correct usage per Launchable API)

## Testing
Verified with urchin-analytics - test recording now succeeds without warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)